### PR TITLE
feat: clamp turret rotation to [-90, 90]

### DIFF
--- a/src/main/java/frc/robot/subsystems/Turret/Turret.kt
+++ b/src/main/java/frc/robot/subsystems/Turret/Turret.kt
@@ -27,7 +27,7 @@ object Turret : Subsystem {
 
     private val turretInputs = TurretInputs()
 
-    const val maxRotationDegrees = 90.0
+    const val MAX_ROTATION_DEGREES = 90.0
     // factoring in rotation of drivetrain
     private var targetRotation: Rotation2d = Rotation2d()
         set(value) {

--- a/src/main/java/frc/robot/subsystems/Turret/Turret.kt
+++ b/src/main/java/frc/robot/subsystems/Turret/Turret.kt
@@ -34,7 +34,7 @@ object Turret : Subsystem {
             var degrees = (value.degrees % 360)
             // spin around to other side if possible
             if (degrees.absoluteValue > 180) {
-                degrees = (degrees.absoluteValue - 180) * degrees.sign
+                degrees = (degrees.absoluteValue - 180) * -degrees.sign
             }
             degrees = degrees.coerceIn(-maxRotationDegrees, maxRotationDegrees)
             field = Rotation2d.fromDegrees(degrees)

--- a/src/main/java/frc/robot/subsystems/Turret/Turret.kt
+++ b/src/main/java/frc/robot/subsystems/Turret/Turret.kt
@@ -8,6 +8,8 @@ import frc.robot.CANDevice
 import frc.robot.subsystems.drivetrain.Drivetrain
 import frc.robot.utils.PIDCoefficients
 import frc.robot.utils.PIDController
+import kotlin.math.absoluteValue
+import kotlin.math.sign
 
 
 object Turret : Subsystem {
@@ -25,8 +27,18 @@ object Turret : Subsystem {
 
     private val turretInputs = TurretInputs()
 
+    const val maxRotationDegrees = 90.0
     // factoring in rotation of drivetrain
     private var targetRotation: Rotation2d = Rotation2d()
+        set(value) {
+            var degrees = (value.degrees % 360)
+            // spin around to other side if possible
+            if (degrees.absoluteValue > 180) {
+                degrees = (degrees.absoluteValue - 180) * degrees.sign
+            }
+            degrees = degrees.coerceIn(-maxRotationDegrees, maxRotationDegrees)
+            field = Rotation2d.fromDegrees(degrees)
+        }
 
 
     override fun periodic() {

--- a/src/main/java/frc/robot/subsystems/Turret/Turret.kt
+++ b/src/main/java/frc/robot/subsystems/Turret/Turret.kt
@@ -31,11 +31,12 @@ object Turret : Subsystem {
     // factoring in rotation of drivetrain
     private var targetRotation: Rotation2d = Rotation2d()
         set(value) {
-            var degrees = (value.degrees % 360)
-            // spin around to other side if possible
-            if (degrees.absoluteValue > 180) {
-                degrees = (degrees.absoluteValue - 180) * -degrees.sign
+            var degrees = value.degrees % 360
+           
+            if(degrees.absoluteValue > 180) {
+                degrees -= 360 * degrees.sign
             }
+            
             degrees = degrees.coerceIn(-maxRotationDegrees, maxRotationDegrees)
             field = Rotation2d.fromDegrees(degrees)
         }


### PR DESCRIPTION
The turret has a 180 degree possible range of rotation according to jonah. I've added a setter to the `targetRotation` field because I assume we don't want to allow storing invalid states. 