### PR TITLE
fix(TurretIO): set gear ratio to 5:1

### DIFF
--- a/src/main/java/frc/robot/subsystems/turret/TurretIO.kt
+++ b/src/main/java/frc/robot/subsystems/turret/TurretIO.kt
@@ -56,8 +56,7 @@ class TurretIOReal(motorCAN: CANDevice) : TurretIO {
     }
 
     internal companion object Constants {
-        // TODO: find turret gear ratio :0
-        const val GEAR_RATIO = 1.0
+        const val GEAR_RATIO = 5.0
     }
 }
 


### PR DESCRIPTION
I ran the formatter so it looks like it also changed some whitespace